### PR TITLE
Goldiloks opt

### DIFF
--- a/benchs/bench.cpp
+++ b/benchs/bench.cpp
@@ -17,7 +17,7 @@
 #define NPHASES_LDE 3
 #define NBLOCKS 1
 
-static void DISABLED_POSEIDON_BENCH_FULL(benchmark::State &state)
+static void POSEIDON_BENCH_FULL(benchmark::State &state)
 {
     uint64_t input_size = (uint64_t)NUM_HASHES * (uint64_t)SPONGE_WIDTH;
 
@@ -54,7 +54,7 @@ static void DISABLED_POSEIDON_BENCH_FULL(benchmark::State &state)
     state.counters["BytesProcessed"] = benchmark::Counter(input_size * sizeof(uint64_t), benchmark::Counter::kIsIterationInvariantRate, benchmark::Counter::OneK::kIs1024);
 }
 
-static void DISABLED_POSEIDON_BENCH(benchmark::State &state)
+static void POSEIDON_BENCH(benchmark::State &state)
 {
     uint64_t input_size = (uint64_t)NUM_HASHES * (uint64_t)SPONGE_WIDTH;
     uint64_t result_size = (uint64_t)NUM_HASHES * (uint64_t)CAPACITY;
@@ -118,6 +118,7 @@ static void NTT_BENCH(benchmark::State &state)
             gntt.NTT(a + offset, a + offset, FFT_SIZE);
         }
     }
+    free(a);
 }
 
 static void NTT_Block_BENCH(benchmark::State &state)
@@ -144,6 +145,7 @@ static void NTT_Block_BENCH(benchmark::State &state)
     {
         gntt.NTT(a, a, FFT_SIZE, NUM_COLUMNS, NPHASES_NTT, NBLOCKS);
     }
+    free(a);
 }
 
 static void LDE_BENCH(benchmark::State &state)
@@ -193,8 +195,11 @@ static void LDE_BENCH(benchmark::State &state)
 
             gntt_extension.NTT(res, res, (FFT_SIZE << BLOWUP_FACTOR));
         }
+        free(res);
     }
     free(zero_array);
+    free(a);
+    free(r);
 }
 
 static void LDE_BENCH_Block(benchmark::State &state)
@@ -248,9 +253,11 @@ static void LDE_BENCH_Block(benchmark::State &state)
     {
         gntt_extension.NTT(a, a, (FFT_SIZE << BLOWUP_FACTOR), NUM_COLUMNS, NPHASES_LDE, NBLOCKS);
     }
+    free(a);
+    free(r);
 }
 
-BENCHMARK(DISABLED_POSEIDON_BENCH_FULL)
+BENCHMARK(POSEIDON_BENCH_FULL)
     ->Unit(benchmark::kMicrosecond)
     ->DenseRange(1, 1, 1)
     ->RangeMultiplier(2)
@@ -258,7 +265,7 @@ BENCHMARK(DISABLED_POSEIDON_BENCH_FULL)
     ->DenseRange(omp_get_max_threads() / 2 - 8, omp_get_max_threads() / 2 + 8, 2)
     ->UseRealTime();
 
-BENCHMARK(DISABLED_POSEIDON_BENCH)
+BENCHMARK(POSEIDON_BENCH)
     ->Unit(benchmark::kMicrosecond)
     ->DenseRange(1, 1, 1)
     ->RangeMultiplier(2)

--- a/src/goldilocks_base_field.hpp
+++ b/src/goldilocks_base_field.hpp
@@ -116,6 +116,7 @@ public:
     static void exp(Element &result, Element base, uint64_t exps);
 
     static void copy(Element &dst, const Element &src) { dst.fe = src.fe; };
+    static void parcpy(Element *dst, const Element *src, uint64_t size, int num_threads_copy);
 };
 
 /*
@@ -581,6 +582,24 @@ inline uint64_t Goldilocks::from_montgomery(const uint64_t &in1)
         : "r"(in1), "m"(MM), "m"(Q), "m"(CQ)
         : "%rax", "%r8", "%r9", "%r10");
     return res;
+}
+inline void Goldilocks::parcpy(Element *dst, const Element *src, uint64_t size, int num_threads_copy)
+{
+    uint64_t dim_total = size * sizeof(Goldilocks::Element);
+    uint64_t dim_thread = dim_total / num_threads_copy;
+    uint64_t components_thread = size / num_threads_copy;
+    uint64_t dim_res = dim_total % num_threads_copy;
+
+#pragma omp parallel num_threads(num_threads_copy) firstprivate(dim_thread)
+    {
+        int id = omp_get_thread_num();
+        uint64_t offset = id * components_thread;
+        if (id == num_threads_copy - 1)
+        {
+            dim_thread += dim_res;
+        }
+        std::memcpy(&dst[offset], &src[offset], dim_thread);
+    }
 }
 
 #endif // GOLDILOCKS

--- a/src/goldilocks_base_field.hpp
+++ b/src/goldilocks_base_field.hpp
@@ -5,6 +5,7 @@
 #include <string>   // string
 #include <gmpxx.h>
 #include <iostream> // string
+#include <omp.h>
 
 #define USE_MONTGOMERY 0
 #define GOLDILOCKS_DEBUG 0

--- a/src/ntt_goldilocks.cpp
+++ b/src/ntt_goldilocks.cpp
@@ -245,14 +245,14 @@ void NTT_Goldilocks::extendPol(Goldilocks::Element *output, Goldilocks::Element 
 
     INTT(tmp, input, N, ncols);
 #pragma omp parallel for
-    for (uint64_t j = 0; j < ncols; j++)
-    {
-        for (uint64_t i = 0; i < N; i++)
+    for (uint64_t i = 0; i < N; i++)
+        for (uint64_t j = 0; j < ncols; j++)
         {
+            {
 
-            Goldilocks::mul(tmp[i * ncols + j], tmp[ncols * i + j], r[i]);
+                Goldilocks::mul(tmp[i * ncols + j], tmp[ncols * i + j], r[i]);
+            }
         }
-    }
 #pragma omp parallel for schedule(static)
     for (uint64_t i = N * ncols; i < N_Extended * ncols; i++)
     {

--- a/src/ntt_goldilocks.hpp
+++ b/src/ntt_goldilocks.hpp
@@ -13,7 +13,7 @@
 class NTT_Goldilocks
 {
 private:
-    u_int32_t s;
+    u_int32_t s = 0;
     u_int32_t nThreads;
     uint64_t nqr;
     Goldilocks::Element *roots;
@@ -37,6 +37,8 @@ private:
 public:
     NTT_Goldilocks(u_int64_t maxDomainSize, u_int32_t _nThreads = 0)
     {
+        if (maxDomainSize == 0)
+            return;
         nThreads = _nThreads == 0 ? omp_get_max_threads() : _nThreads;
 
         u_int32_t domainPow = NTT_Goldilocks::log2(maxDomainSize);
@@ -118,8 +120,11 @@ public:
     };
     ~NTT_Goldilocks()
     {
-        free(roots);
-        free(powTwoInv);
+        if (s != 0)
+        {
+            free(roots);
+            free(powTwoInv);
+        }
     }
 
     void NTT(Goldilocks::Element *dst, Goldilocks::Element *src, u_int64_t size, u_int64_t ncols = 1, u_int64_t nphase = NUM_PHASES, u_int64_t nblock = NUM_BLOCKS);

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -254,6 +254,8 @@ TEST(GOLDILOCKS_TEST, ntt)
     {
         ASSERT_EQ(Goldilocks::toU64(a[i]), Goldilocks::toU64(initial[i]));
     }
+    free(a);
+    free(initial);
 }
 
 TEST(GOLDILOCKS_TEST, ntt_block)
@@ -342,6 +344,8 @@ TEST(GOLDILOCKS_TEST, ntt_block)
     {
         ASSERT_EQ(Goldilocks::toU64(a[i]), Goldilocks::toU64(initial[i]));
     }
+    free(a);
+    free(initial);
 }
 
 TEST(GOLDILOCKS_TEST, LDE)
@@ -417,6 +421,10 @@ TEST(GOLDILOCKS_TEST, LDE)
     ASSERT_EQ(Goldilocks::toU64(a[29]), 0X48161FC7B47B998E);
     ASSERT_EQ(Goldilocks::toU64(a[30]), 0X5144C235578455C6);
     ASSERT_EQ(Goldilocks::toU64(a[31]), 0XAF5244B5C1134635);
+
+    free(a);
+    free(zeros_array);
+    free(r);
 }
 
 TEST(GOLDILOCKS_TEST, LDE_block)
@@ -501,6 +509,9 @@ TEST(GOLDILOCKS_TEST, LDE_block)
     ASSERT_EQ(Goldilocks::toU64(a[29 * NUM_COLUMNS]), 0X48161FC7B47B998E);
     ASSERT_EQ(Goldilocks::toU64(a[30 * NUM_COLUMNS]), 0X5144C235578455C6);
     ASSERT_EQ(Goldilocks::toU64(a[31 * NUM_COLUMNS]), 0XAF5244B5C1134635);
+
+    free(a);
+    free(r);
 }
 
 TEST(GOLDILOCKS_CUBIC_TEST, one)


### PR DESCRIPTION
* Added function parcpy for parallel memory copies using openmp and memcpy
* Solved some memory issues for edge cases (e.g. initialization of ntt with size 0)
* Changed loops ordering for performance in extendPol
* added memory deallocations in bench.cpp and test.cpp