### PR TITLE
Ntt phases parity overhead

### DIFF
--- a/benchs/bench.cpp
+++ b/benchs/bench.cpp
@@ -13,8 +13,8 @@
 #define FFT_SIZE (1 << 23)
 #define NUM_COLUMNS 100
 #define BLOWUP_FACTOR 1
-#define NPHASES_NTT 3
-#define NPHASES_LDE 3
+#define NPHASES_NTT 2
+#define NPHASES_LDE 2
 #define NBLOCKS 1
 
 static void POSEIDON_BENCH_FULL(benchmark::State &state)
@@ -279,7 +279,7 @@ BENCHMARK(NTT_BENCH)
     //->RangeMultiplier(2)
     //->Range(2, omp_get_max_threads())
     //->DenseRange(omp_get_max_threads() / 2 - 8, omp_get_max_threads() / 2 + 8, 2)
-    ->DenseRange(omp_get_max_threads(), omp_get_max_threads(), 1)
+    ->DenseRange(omp_get_max_threads() / 2, omp_get_max_threads() / 2, 1)
     ->UseRealTime();
 
 BENCHMARK(NTT_Block_BENCH)
@@ -288,7 +288,7 @@ BENCHMARK(NTT_Block_BENCH)
     //->RangeMultiplier(2)
     //->Range(2, omp_get_max_threads())
     //->DenseRange(omp_get_max_threads() / 2 - 8, omp_get_max_threads() / 2 + 8, 2)
-    ->DenseRange(omp_get_max_threads(), omp_get_max_threads(), 1)
+    ->DenseRange(omp_get_max_threads() / 2, omp_get_max_threads() / 2, 1)
     ->UseRealTime();
 
 BENCHMARK(LDE_BENCH)
@@ -297,7 +297,7 @@ BENCHMARK(LDE_BENCH)
     //->RangeMultiplier(2)
     //->Range(2, omp_get_max_threads())
     //->DenseRange(omp_get_max_threads() / 2 - 8, omp_get_max_threads() / 2 + 8, 2)
-    ->DenseRange(omp_get_max_threads(), omp_get_max_threads(), 1)
+    ->DenseRange(omp_get_max_threads() / 2, omp_get_max_threads() / 2, 1)
     ->UseRealTime();
 BENCHMARK(LDE_BENCH_Block)
     ->Unit(benchmark::kSecond)
@@ -305,7 +305,7 @@ BENCHMARK(LDE_BENCH_Block)
     //->RangeMultiplier(2)
     //->Range(2, omp_get_max_threads())
     //->DenseRange(omp_get_max_threads() / 2 - 8, omp_get_max_threads() / 2 + 8, 2)
-    ->DenseRange(omp_get_max_threads(), omp_get_max_threads(), 1)
+    ->DenseRange(omp_get_max_threads() / 2, omp_get_max_threads() / 2, 1)
     ->UseRealTime();
 
 BENCHMARK_MAIN();

--- a/src/ntt_goldilocks.cpp
+++ b/src/ntt_goldilocks.cpp
@@ -40,9 +40,6 @@ void NTT_Goldilocks::NTT_iters(Goldilocks::Element *dst, Goldilocks::Element *sr
     {
         maxBatchPow += 1;
     }
-    u_int64_t batchSize = 1 << maxBatchPow;
-    u_int64_t nBatches = size / batchSize;
-
     bool iseven = true;
     tmp = a;
     if (nphase % 2 == 1)

--- a/src/ntt_goldilocks.cpp
+++ b/src/ntt_goldilocks.cpp
@@ -121,6 +121,7 @@ void NTT_Goldilocks::NTT_iters(Goldilocks::Element *dst, Goldilocks::Element *sr
     }
     if (a != dst_)
     {
+        assert(0);
 #pragma omp parallel for schedule(static)
         for (u_int64_t ie = 0; ie < size; ++ie)
         {
@@ -203,16 +204,7 @@ void NTT_Goldilocks::reversePermutation(Goldilocks::Element *dst, Goldilocks::El
             u_int64_t r = BR(i, domainSize);
             u_int64_t offset_r1 = r * ncols_all + offset_cols;
             u_int64_t offset_i1 = i * ncols;
-            u_int64_t offset_i2 = i * ncols_all + offset_cols;
-            u_int64_t offset_r2 = r * ncols;
-            if (r <= i)
-            {
-                std::memcpy(&dst[offset_i1], &src[offset_r1], ncols * sizeof(Goldilocks::Element));
-                if (r != i)
-                {
-                    std::memcpy(&dst[offset_r2], &src[offset_i2], ncols * sizeof(Goldilocks::Element));
-                }
-            }
+            std::memcpy(&dst[offset_i1], &src[offset_r1], ncols * sizeof(Goldilocks::Element));
         }
     }
     else


### PR DESCRIPTION
1) When the number of phases of the NTT was an even number a copy between the auxiliar buffer and the output buffer was necessary at the end of the NTT iterations... this was avoided by doing an on-site reversePermutation in case nphase is even number.

2) Evaluation of parameter sInc (steps per phase) has been revised, current version is faster

3) Minor tunnings in the benchmark