### PR TITLE
fix the bug of miss vector lib in the hpp file

### DIFF
--- a/src/goldilocks_cubic_extension.hpp
+++ b/src/goldilocks_cubic_extension.hpp
@@ -4,6 +4,7 @@
 #include <stdint.h> // for uint64_t
 #include "goldilocks_base_field.hpp"
 #include <cassert>
+#include <vector>
 
 #define FIELD_EXTENSION 3
 


### PR DESCRIPTION
fix the bug of miss vector lib in the hpp file of src/goldilocks_cubic_extension.hpp