### PR TITLE
Properly initialize input for NTT_BENCH benchmark

### DIFF
--- a/benchs/bench.cpp
+++ b/benchs/bench.cpp
@@ -396,7 +396,7 @@ static void NTT_BENCH(benchmark::State &state)
         a[offset + 1] = Goldilocks::one();
         for (uint64_t i = 2; i < FFT_SIZE; i++)
         {
-            a[i] = a[i - 1] + a[i - 2];
+            a[offset + i] = a[offset + i - 1] + a[offset + i - 2];
         }
     }
     for (auto _ : state)


### PR DESCRIPTION
As written the benchmark only initializes the first column of the test input. Since the array is allocated with malloc and left uninitialized, this is technically undefined behavior in the benchmark.