### PR TITLE
Add missing include

### DIFF
--- a/src/goldilocks_cubic_extension.hpp
+++ b/src/goldilocks_cubic_extension.hpp
@@ -5,6 +5,7 @@
 #include "goldilocks_base_field.hpp"
 #include <immintrin.h>
 #include <cassert>
+#include <vector>
 
 #define FIELD_EXTENSION 3
 


### PR DESCRIPTION
This commit adds `#include <vector>` to the headers for `goldilocks_cubic_extension`.

I don't know how this code compiles for others with this header missing, but it doesn't for me.